### PR TITLE
Change the plugin repository version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.7.0-SNAPSHOT</version>
+    <version>3.7.1-02</version>
   </parent>
   <groupId>org.sonatype.repository</groupId>
   <artifactId>nexus-repository-conan</artifactId>

--- a/src/test/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGeneratorTest.java
+++ b/src/test/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGeneratorTest.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.sonatype.goodies.testsupport.TestSupport;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
-import org.sonatype.nexus.repository.storage.DefaultComponent;
+import org.sonatype.nexus.repository.storage.Component;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -24,7 +24,7 @@ public class ConanBrowseNodeGeneratorTest
 
   @Before
   public void setUp() throws Exception {
-    component = new DefaultComponent().group("vthiery")
+    component = new Component().group("vthiery")
         .name("jsonformoderncpp")
         .version("2.1.1");
   }


### PR DESCRIPTION
The project pulled from master does not build.
I changed the version of nexus-plugin to an existing one, and replaced DefaultComponent with Component (as I saw in other projects).
Now it builds correctly, but when I load it into Nexus and try to create a new repository, it only allows me to create "Conan (proxy)" type repos.

When starting the plugin, the following warnings are shown:
```2018-01-16 17:50:52,357+0200 WARN  [Karaf local console user karaf] *SYSTEM com.google.inject.spi.InjectionPoint - Method: public void org.sonatype.repository.conan.internal.ConanRecipeSupport.setBrowseUnsupportedHandler(org.sonatype.nexus.repository.view.handlers.BrowseUnsupportedHandler) is not annotated with @Inject but is overriding a method that is annotated with @javax.inject.Inject.  Because it is not annotated with @Inject, the method will not be injected. To fix this, annotate the method with @Inject.

2018-01-16 17:50:52,373+0200 WARN  [Karaf local console user karaf] *SYSTEM com.google.inject.spi.InjectionPoint - Method: public void org.sonatype.repository.conan.internal.ConanRecipeSupport.setBrowseUnsupportedHandler(org.sonatype.nexus.repository.view.handlers.BrowseUnsupportedHandler) is not annotated with @Inject but is overriding a method that is annotated with @javax.inject.Inject.  Because it is not annotated with @Inject, the method will not be injected. To fix this, annotate the method with @Inject.
```
