### PR TITLE
Enabling the download of sources

### DIFF
--- a/src/main/java/org/sonatype/repository/conan/internal/proxy/ConanProxyRecipe.groovy
+++ b/src/main/java/org/sonatype/repository/conan/internal/proxy/ConanProxyRecipe.groovy
@@ -241,8 +241,8 @@ class ConanProxyRecipe
           new ActionMatcher(GET, HEAD),
           conanInfoMatcher()
       )
-  )
-}
+    )
+  }
 
   static TokenMatcher conanInfoMatcher() {
     new TokenMatcher("/{${AUTHOR}:.+}/{${PROJECT}:.+}/{${VERSION}:.+}/{${STATE}:.+}/package/{sha:.+}/conaninfo.txt")
@@ -252,12 +252,19 @@ class ConanProxyRecipe
     new Builder().matcher(
         and(
             new ActionMatcher(GET, HEAD),
-            conanPackageMatcher()
+            or(
+              conanPackageMatcher(),
+              conanSourcesMatcher()
+            )
         )
     )
   }
 
   static TokenMatcher conanPackageMatcher() {
     new TokenMatcher("/{${AUTHOR}:.+}/{${PROJECT}:.+}/{${VERSION}:.+}/{${STATE}:.+}/package/{sha:.+}/conan_package.tgz")
+  }
+
+  static TokenMatcher conanSourcesMatcher() {
+    new TokenMatcher("/{${AUTHOR}:.+}/{${PROJECT}:.+}/{${VERSION}:.+}/{${STATE}:.+}/export/conan_sources.tgz")
   }
 }


### PR DESCRIPTION
The example poco install required to download the sources because the pre-built binaries where not available for my architecture. This allow sources to be downloaded and then built locally
