### PR TITLE
Update to 0.0.2, update Nexus Repo version, fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ FROM sonatype/nexus3:$NEXUS_VERSION
 ARG NEXUS_VERSION=3.11.0
 ARG NEXUS_BUILD=01
 ARG CONAN_VERSION=0.0.2
-ARG TARGET_DIR=/opt/sonatype/nexus/system/org/sonatype/nexus/plugins/nexus-repository-conan/${COMPOSER_VERSION}/
+ARG TARGET_DIR=/opt/sonatype/nexus/system/org/sonatype/nexus/plugins/nexus-repository-conan/${CONAN_VERSION}/
 USER root
 RUN mkdir -p ${TARGET_DIR}; \
-    sed -i 's@nexus-repository-npm</feature>@nexus-repository-npm</feature>\n        <feature prerequisite="false" dependency="false">nexus-repository-conan</feature>@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-oss-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml; \
-    sed -i 's@<feature name="nexus-repository-npm"@<feature name="nexus-repository-conan" description="org.sonatype.nexus.plugins:nexus-repository-conan" version="0.0.2">\n        <details>org.sonatype.nexus.plugins:nexus-repository-conan/details>\n        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-conan/0.0.2</bundle>\n    </feature>\n    <feature name="nexus-repository-npm"@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-oss-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml;
+    sed -i 's@nexus-repository-maven</feature>@nexus-repository-maven</feature>\n        <feature prerequisite="false" dependency="false" version="0.0.2">nexus-repository-conan</feature>@g' /opt/sonatype/nexus/system/org/sonatype/nexus/assemblies/nexus-core-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-core-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml; \
+    sed -i 's@<feature name="nexus-repository-maven"@<feature name="nexus-repository-conan" description="org.sonatype.nexus.plugins:nexus-repository-conan" version="0.0.2">\n        <details>org.sonatype.nexus.plugins:nexus-repository-conan</details>\n        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-conan/0.0.2</bundle>\n    </feature>\n    <feature name="nexus-repository-maven"@g' /opt/sonatype/nexus/system/org/sonatype/nexus/assemblies/nexus-core-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-core-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml;
 COPY --from=build /nexus-repository-conan/target/nexus-repository-conan-${CONAN_VERSION}.jar ${TARGET_DIR}
 USER nexus

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-ARG NEXUS_VERSION=3.8.0
+ARG NEXUS_VERSION=3.11.0
 
 FROM maven:3-jdk-8-alpine AS build
-ARG NEXUS_VERSION=3.8.0
-ARG NEXUS_BUILD=02
+ARG NEXUS_VERSION=3.11.0
+ARG NEXUS_BUILD=01
 
 COPY . /nexus-repository-conan/
-RUN cd /nexus-repository-conan/; sed -i "s/3.8.0-02/${NEXUS_VERSION}-${NEXUS_BUILD}/g" pom.xml; \
+RUN cd /nexus-repository-conan/; sed -i "s/3.11.0-01/${NEXUS_VERSION}-${NEXUS_BUILD}/g" pom.xml; \
     mvn clean package;
 
 FROM sonatype/nexus3:$NEXUS_VERSION
-ARG NEXUS_VERSION=3.8.0
-ARG NEXUS_BUILD=02
-ARG CONAN_VERSION=0.0.1
+ARG NEXUS_VERSION=3.11.0
+ARG NEXUS_BUILD=01
+ARG CONAN_VERSION=0.0.2
 ARG TARGET_DIR=/opt/sonatype/nexus/system/org/sonatype/nexus/plugins/nexus-repository-conan/${COMPOSER_VERSION}/
 USER root
 RUN mkdir -p ${TARGET_DIR}; \
     sed -i 's@nexus-repository-npm</feature>@nexus-repository-npm</feature>\n        <feature prerequisite="false" dependency="false">nexus-repository-conan</feature>@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-oss-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml; \
-    sed -i 's@<feature name="nexus-repository-npm"@<feature name="nexus-repository-conan" description="org.sonatype.nexus.plugins:nexus-repository-conan" version="0.0.1">\n        <details>org.sonatype.nexus.plugins:nexus-repository-conan2</details>\n        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-conan/0.0.1</bundle>\n    </feature>\n    <feature name="nexus-repository-npm"@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-oss-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml;
+    sed -i 's@<feature name="nexus-repository-npm"@<feature name="nexus-repository-conan" description="org.sonatype.nexus.plugins:nexus-repository-conan" version="0.0.2">\n        <details>org.sonatype.nexus.plugins:nexus-repository-conan/details>\n        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-conan/0.0.2</bundle>\n    </feature>\n    <feature name="nexus-repository-npm"@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-oss-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml;
 COPY --from=build /nexus-repository-conan/target/nexus-repository-conan-${CONAN_VERSION}.jar ${TARGET_DIR}
 USER nexus

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ If everything checks out, the bundle for Conan should be available in the `targe
 
 #### Build with Docker
 
-`docker build -t nexus-repository-conan:0.0.1 .`
+`docker build -t nexus-repository-conan:0.0.2 .`
 
 #### Run as a Docker container
 
-`docker run -d -p 8081:8081 --name nexus nexus-repository-conan:0.0.1` 
+`docker run -d -p 8081:8081 --name nexus nexus-repository-conan:0.0.2` 
 
 For further information like how to persist volumes check out [the GitHub repo for our official image](https://github.com/sonatype/docker-nexus3).
 
@@ -86,7 +86,7 @@ good installation path if you are just testing or doing development on the plugi
   # sudo su - nexus
   $ cd <nexus_dir>/bin
   $ ./nexus run
-  > bundle:install file:///tmp/nexus-repository-conan-0.0.1.jar
+  > bundle:install file:///tmp/nexus-repository-conan-0.0.2.jar
   > bundle:list
   ```
   (look for org.sonatype.nexus.plugins:nexus-repository-conan ID, should be the last one)
@@ -98,7 +98,7 @@ good installation path if you are just testing or doing development on the plugi
 
 For more permanent installs of the nexus-repository-conan plugin, follow these instructions:
 
-* Copy the bundle (nexus-repository-conan-0.0.1.jar) into <nexus_dir>/deploy
+* Copy the bundle (nexus-repository-conan-0.0.2.jar) into <nexus_dir>/deploy
 
 This will cause the plugin to be loaded with each restart of Nexus Repository. As well, this folder is monitored
 by Nexus Repository and the plugin should load within 60 seconds of being copied there if Nexus Repository
@@ -108,20 +108,20 @@ is running. You will still need to start the bundle using the karaf commands men
 
 If you are trying to use the Conan plugin permanently, it likely makes more sense to do the following:
 
-* Copy the bundle into `<nexus_dir>/system/org/sonatype/nexus/plugins/nexus-repository-conan/0.0.1/nexus-repository-conan-0.0.1.jar`
+* Copy the bundle into `<nexus_dir>/system/org/sonatype/nexus/plugins/nexus-repository-conan/0.0.2/nexus-repository-conan-0.0.2.jar`
 * If you are using OSS edition, make these mods in: `<nexus_dir>/system/com/sonatype/nexus/assemblies/nexus-oss-feature/3.x.y/nexus-oss-feature-3.x.y-features.xml`
 * If you are using PRO edition, make these mods in: `<nexus_dir>/system/com/sonatype/nexus/assemblies/nexus-pro-feature/3.x.y/nexus-pro-feature-3.x.y-features.xml`
    ```
          <feature version="3.x.y.xy" prerequisite="false" dependency="false">nexus-repository-rubygems</feature>
-         <feature version="0.0.1" prerequisite="false" dependency="false">nexus-repository-conan</feature>
+         <feature version="0.0.2" prerequisite="false" dependency="false">nexus-repository-conan</feature>
          <feature version="3.x.y.xy" prerequisite="false" dependency="false">nexus-repository-yum</feature>
      </features>
    ```
    And
    ```
-       <feature name="nexus-repository-conan" description="org.sonatype.nexus.plugins:nexus-repository-conan" version="0.0.1">
+       <feature name="nexus-repository-conan" description="org.sonatype.nexus.plugins:nexus-repository-conan" version="0.0.2">
         <details>org.sonatype.nexus.plugins:nexus-repository-conan</details>
-        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-conan/0.0.1</bundle>
+        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-conan/0.0.2</bundle>
        </feature>
     </features>
    ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ we would like things to flow.
 
 Also, there is a good amount of information available at [Bundle Development](https://help.sonatype.com/display/NXRM3/Bundle+Development#BundleDevelopment-BundleDevelopmentOverview)
 
+NOTE: Version 0.0.2 of Conan is only compatible with Nexus Repo 3.11.0 or greater due to adding Tree View Filtering. If 
+you need to use this plugin with an older version, please use 0.0.1
+
 ### Building
 
 To build the project and generate the bundle use Maven

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.sonatype.repository</groupId>
   <artifactId>nexus-repository-conan</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
-  <version>0.0.2-SNAPSHOT</version>
+  <version>0.0.2</version>
   <inceptionYear>2017</inceptionYear>
   <packaging>bundle</packaging>
 

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedFacet.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedFacet.java
@@ -64,7 +64,7 @@ import static org.sonatype.repository.conan.internal.proxy.ConanProxyHelper.toCo
 import static org.sonatype.repository.conan.internal.utils.ConanFacetUtils.findComponent;
 
 /**
- * @since conan.next
+ * @since 0.0.2
  */
 @Exposed
 @Named

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedRecipe.groovy
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedRecipe.groovy
@@ -56,7 +56,7 @@ import static org.sonatype.repository.conan.internal.metadata.ConanMetadata.STAT
 import static org.sonatype.repository.conan.internal.metadata.ConanMetadata.VERSION
 
 /**
- * @since conan.next
+ * @since 0.0.2
  */
 @Named(ConanHostedRecipe.NAME)
 @Singleton

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/HostedHandlers.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/HostedHandlers.java
@@ -36,7 +36,7 @@ import static org.sonatype.repository.conan.internal.metadata.ConanCoords.getPat
 import static org.sonatype.repository.conan.internal.metadata.ConanMetadata.DIGEST;
 
 /**
- * @since conan.next
+ * @since 0.0.2
  */
 @Named
 @Singleton

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/UploadUrlManager.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/UploadUrlManager.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * value is the asset to be added. This class generates url links to where the
  * asset locations will be once stored.
  * Note: the data is stored wihout the host utl prefixed.
- * @since conan.next
+ * @since 0.0.2
  */
 public class UploadUrlManager
     extends ComponentSupport

--- a/src/main/java/org/sonatype/repository/conan/internal/security/token/ConanToken.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/security/token/ConanToken.java
@@ -18,7 +18,7 @@ import javax.inject.Singleton;
 import org.sonatype.nexus.security.token.BearerToken;
 
 /**
- * @since conan.next
+ * @since 0.0.2
  */
 @Named(ConanToken.NAME)
 @Singleton

--- a/src/main/java/org/sonatype/repository/conan/internal/security/token/ConanTokenFacet.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/security/token/ConanTokenFacet.java
@@ -18,7 +18,7 @@ import org.sonatype.nexus.repository.view.Context;
 import org.sonatype.nexus.repository.view.Response;
 
 /**
- * @since conan.next
+ * @since 0.0.2
  */
 @Exposed
 public interface ConanTokenFacet

--- a/src/main/java/org/sonatype/repository/conan/internal/security/token/ConanTokenFacetImpl.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/security/token/ConanTokenFacetImpl.java
@@ -27,7 +27,7 @@ import static org.sonatype.nexus.repository.http.HttpStatus.UNAUTHORIZED;
 import static org.sonatype.nexus.repository.view.ContentTypes.TEXT_PLAIN;
 
 /**
- * @since conan.next
+ * @since 0.0.2
  */
 @Named
 public class ConanTokenFacetImpl

--- a/src/main/java/org/sonatype/repository/conan/internal/security/token/ConanTokenManager.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/security/token/ConanTokenManager.java
@@ -26,7 +26,7 @@ import org.apache.shiro.subject.Subject;
 import static org.sonatype.nexus.security.anonymous.AnonymousHelper.isAnonymous;
 
 /**
- * @since conan.next
+ * @since 0.0.2
  */
 @Named
 @Singleton

--- a/src/main/java/org/sonatype/repository/conan/internal/security/token/ConanTokenRealm.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/security/token/ConanTokenRealm.java
@@ -23,7 +23,7 @@ import org.sonatype.nexus.security.token.BearerTokenRealm;
 import org.eclipse.sisu.Description;
 
 /**
- * @since conan.next
+ * @since 0.0.2
  */
 @Named
 @Singleton


### PR DESCRIPTION
This gets ready for a `0.0.2` release, and updates a few other tiny things.

This pull request makes the following changes:
* Updates `conan.next` references to `0.0.2`
* Updates `pom.xml` to `0.0.2`
* Updates `Dockerfile` to use newest Nexus Repo release, and to `0.0.2`
* Updates `README.md` to use `0.0.2`
