### PR TITLE
Fix conan_export.tgz error by adding missing download route.

### DIFF
--- a/src/main/java/org/sonatype/repository/conan/internal/AssetKind.groovy
+++ b/src/main/java/org/sonatype/repository/conan/internal/AssetKind.groovy
@@ -25,7 +25,8 @@ enum AssetKind {
   CONAN_FILE(METADATA, "conanfile.py"),
   CONAN_INFO(METADATA, "conaninfo.txt"),
   CONAN_PACKAGE(METADATA, "conan_package.tgz"),
-  CONAN_SOURCES(METADATA, "conan_sources.tgz")
+  CONAN_SOURCES(METADATA, "conan_sources.tgz"),
+  CONAN_EXPORT(METADATA, "conan_export.tgz")
 
   private final CacheType cacheType
 

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedRecipe.groovy
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedRecipe.groovy
@@ -167,7 +167,7 @@ class ConanHostedRecipe
     createRoute(builder, downloadConaninfo(), CONAN_INFO, hostedHandler.download)
     createRoute(builder, downloadConanPackageZip(), CONAN_PACKAGE, hostedHandler.download)
     createRoute(builder, downloadConanSources(), AssetKind.CONAN_SOURCES, hostedHandler.download)
-    createRoute(builder, downloadConanExportZip(), AssetKind.CONAN_EXPORT, hostedHandler.download)
+    createRoute(builder, downloadConanExportZip(), CONAN_EXPORT, hostedHandler.download)
 
     builder.route(ping()
         .handler(timingHandler)

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedRecipe.groovy
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedRecipe.groovy
@@ -159,7 +159,7 @@ class ConanHostedRecipe
     createRoute(builder, uploadConaninfo(), CONAN_INFO, hostedHandler.uploadConanInfo)
     createRoute(builder, uploadConanPackageZip(), CONAN_PACKAGE, hostedHandler.uploadConanPackage)
     createRoute(builder, uploadConanSources(), AssetKind.CONAN_SOURCES, hostedHandler.uploadConanSources)
-    createRoute(builder, uploadConanExportZip(), AssetKind.CONAN_EXPORT, hostedHandler.uploadConanExport)
+    createRoute(builder, uploadConanExportZip(), CONAN_EXPORT, hostedHandler.uploadConanExport)
 
     createRoute(builder, downloadUrls(), AssetKind.DOWNLOAD_URL, hostedHandler.downloadUrl)
     createRoute(builder, downloadManifest(), CONAN_MANIFEST, hostedHandler.download)

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedRecipe.groovy
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedRecipe.groovy
@@ -159,7 +159,7 @@ class ConanHostedRecipe
     createRoute(builder, uploadConaninfo(), CONAN_INFO, hostedHandler.uploadConanInfo)
     createRoute(builder, uploadConanPackageZip(), CONAN_PACKAGE, hostedHandler.uploadConanPackage)
     createRoute(builder, uploadConanSources(), AssetKind.CONAN_SOURCES, hostedHandler.uploadConanSources)
-    createRoute(builder, uploadConanExportZip(), CONAN_PACKAGE, hostedHandler.uploadConanExport)
+    createRoute(builder, uploadConanExportZip(), AssetKind.CONAN_EXPORT, hostedHandler.uploadConanExport)
 
     createRoute(builder, downloadUrls(), AssetKind.DOWNLOAD_URL, hostedHandler.downloadUrl)
     createRoute(builder, downloadManifest(), CONAN_MANIFEST, hostedHandler.download)
@@ -167,6 +167,7 @@ class ConanHostedRecipe
     createRoute(builder, downloadConaninfo(), CONAN_INFO, hostedHandler.download)
     createRoute(builder, downloadConanPackageZip(), CONAN_PACKAGE, hostedHandler.download)
     createRoute(builder, downloadConanSources(), AssetKind.CONAN_SOURCES, hostedHandler.download)
+    createRoute(builder, downloadConanExportZip(), AssetKind.CONAN_EXPORT, hostedHandler.download)
 
     builder.route(ping()
         .handler(timingHandler)
@@ -381,6 +382,15 @@ class ConanHostedRecipe
             new ActionMatcher(HEAD, GET),
             new TokenMatcher(CONAN_PACKAGE_ZIP_URL)
         )
+    )
+  }
+
+  static Builder downloadConanExportZip() {
+    new Builder().matcher(
+            and(
+                    new ActionMatcher(HEAD, GET),
+                    new TokenMatcher(CONAN_EXPORT_ZIP_URL)
+            )
     )
   }
 

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedRecipe.groovy
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedRecipe.groovy
@@ -49,6 +49,7 @@ import static org.sonatype.repository.conan.internal.AssetKind.CONAN_FILE
 import static org.sonatype.repository.conan.internal.AssetKind.CONAN_INFO
 import static org.sonatype.repository.conan.internal.AssetKind.CONAN_MANIFEST
 import static org.sonatype.repository.conan.internal.AssetKind.CONAN_PACKAGE
+import static org.sonatype.repository.conan.internal.AssetKind.CONAN_EXPORT
 
 import static org.sonatype.repository.conan.internal.metadata.ConanMetadata.DIGEST
 import static org.sonatype.repository.conan.internal.metadata.ConanMetadata.GROUP
@@ -165,9 +166,9 @@ class ConanHostedRecipe
     createRoute(builder, downloadManifest(), CONAN_MANIFEST, hostedHandler.download)
     createRoute(builder, downloadConanfile(), CONAN_FILE, hostedHandler.download)
     createRoute(builder, downloadConaninfo(), CONAN_INFO, hostedHandler.download)
-    createRoute(builder, downloadConanPackageZip(), CONAN_PACKAGE, hostedHandler.download)
-    createRoute(builder, downloadConanSources(), AssetKind.CONAN_SOURCES, hostedHandler.download)
-    createRoute(builder, downloadConanExportZip(), CONAN_EXPORT, hostedHandler.download)
+    createRoute(builder, downloadConanTgz(CONAN_PACKAGE_ZIP_URL), CONAN_PACKAGE, hostedHandler.download)
+    createRoute(builder, downloadConanTgz(CONAN_SOURCES_URL), AssetKind.CONAN_SOURCES, hostedHandler.download)
+    createRoute(builder, downloadConanTgz(CONAN_EXPORT_ZIP_URL), CONAN_EXPORT, hostedHandler.download)
 
     builder.route(ping()
         .handler(timingHandler)
@@ -376,30 +377,13 @@ class ConanHostedRecipe
     )
   }
 
-  static Builder downloadConanPackageZip() {
-    new Builder().matcher(
-        and(
-            new ActionMatcher(HEAD, GET),
-            new TokenMatcher(CONAN_PACKAGE_ZIP_URL)
-        )
-    )
-  }
 
-  static Builder downloadConanExportZip() {
+  static Builder downloadConanTgz(final String url) {
     new Builder().matcher(
             and(
                     new ActionMatcher(HEAD, GET),
-                    new TokenMatcher(CONAN_EXPORT_ZIP_URL)
+                    new TokenMatcher(url)
             )
-    )
-  }
-
-  static Builder downloadConanSources() {
-    new Builder().matcher(
-        and(
-            new ActionMatcher(HEAD, GET),
-            new TokenMatcher(CONAN_SOURCES_URL)
-        )
     )
   }
 


### PR DESCRIPTION
Fix for issue #36 

This pull request makes the following changes:
* adds route for downloading conan_export.tgz
* adds separate AssetKind for conan_export.tgz (probably it is not required, but I changed it for code readability)

It can be tested on its own via NEXUS Browse page, testing via Conan client requires fix for download_url #34, which has not been merged to master.
