### PR TITLE
Allow uploading with conan client 1.12+(due to added checkum header)

### DIFF
--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/HostedHandlers.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/HostedHandlers.java
@@ -79,7 +79,9 @@ public class HostedHandlers
     TODO Check the SHA1 against existing asset to determine if an upload is required
      */
     Headers headers = context.getRequest().getHeaders();
-    if(headers.contains(CLIENT_CHECKSUM)) {
+    String method = context.getRequest().getAction();
+    
+    if(headers.contains(CLIENT_CHECKSUM) && method != "PUT") {
       return new Response.Builder()
           .status(Status.failure(NOT_FOUND))
           .build();


### PR DESCRIPTION
Allow upload file "PUT" requests to succeed(instead of returning 404) with conan 1.12+, older versions of conan did not add the CHECKSUM header therefore succeeded to upload the files.

After researching the issue, I figured out that the way conan

This pull request makes the following changes:
* Don't return 404 if the request method is PUT

It relates to the following issue #s:
* Fixes #52 
