### PR TITLE
Version range patch

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>nexus-repository-conan</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,7 @@ Sonatype internal people:
 External contributors:
 
 ![Possibly You!](http://i.imgur.com/A3eScYul.jpg)
+
+Ankit Koirala
+
+Jasper van de Ven

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
       <artifactId>nexus-rapture</artifactId>
       <scope>provided</scope>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedFacet.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/ConanHostedFacet.java
@@ -92,7 +92,8 @@ public class ConanHostedFacet
   public Response uploadDownloadUrl(final String assetPath,
                                     final ConanCoords coord,
                                     final Payload payload,
-                                    final AssetKind assetKind) throws IOException {
+                                    final AssetKind assetKind) throws IOException
+  {
     checkNotNull(assetPath);
     checkNotNull(coord);
     checkNotNull(payload);
@@ -127,7 +128,8 @@ public class ConanHostedFacet
   public Response upload(final String assetPath,
                          final ConanCoords coord,
                          final Payload payload,
-                         final AssetKind assetKind) throws IOException {
+                         final AssetKind assetKind) throws IOException
+  {
     checkNotNull(assetPath);
     checkNotNull(coord);
     checkNotNull(payload);
@@ -213,6 +215,7 @@ public class ConanHostedFacet
 
   /**
    * Services the download_urls endpoint for root and package data
+   *
    * @param gavPath path as GAV
    * @param context
    * @return json response of conan files to lookup
@@ -222,7 +225,7 @@ public class ConanHostedFacet
     log.debug("Original request {} is fetching locally from {}", context.getRequest().getPath(), gavPath);
 
     Content content = doGet(gavPath);
-    if(content == null) {
+    if (content == null) {
       return HttpResponses.notFound();
     }
 
@@ -248,7 +251,8 @@ public class ConanHostedFacet
     return new Response.Builder()
         .status(success(OK))
         .payload(new StreamPayload(
-            new InputStreamSupplier() {
+            new InputStreamSupplier()
+            {
               @Nonnull
               @Override
               public InputStream get() throws IOException {

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/search/ConanHostedSearchFacet.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/search/ConanHostedSearchFacet.java
@@ -1,0 +1,24 @@
+package org.sonatype.repository.conan.internal.hosted.search;
+
+import java.io.IOException;
+
+import org.sonatype.nexus.repository.Facet;
+import org.sonatype.nexus.repository.Facet.Exposed;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.Context;
+
+@Exposed
+public interface ConanHostedSearchFacet
+    extends Facet
+{
+  /**
+   * Fetches recipe based on rest queries ?q=
+   */
+  Content searchRecipes(final Context context);
+
+  /**
+   * Returs package info for a fully matching search qualifier:
+   * eg: Poco/1.7.8p3@pocoproject/stable
+   */
+  Content searchPackages(final Context context);
+}

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/search/ConanHostedSearchFacetImpl.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/search/ConanHostedSearchFacetImpl.java
@@ -1,0 +1,87 @@
+package org.sonatype.repository.conan.internal.hosted.search;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.sonatype.nexus.repository.FacetSupport;
+import org.sonatype.nexus.repository.search.SearchService;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.ContentTypes;
+import org.sonatype.nexus.repository.view.Context;
+import org.sonatype.nexus.repository.view.Parameters;
+import org.sonatype.nexus.repository.view.Request;
+import org.sonatype.nexus.repository.view.payloads.StringPayload;
+import org.sonatype.repository.conan.internal.metadata.ConanCoords;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+
+import com.google.gson.JsonArray;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Named
+public class ConanHostedSearchFacetImpl
+    extends FacetSupport
+    implements ConanHostedSearchFacet
+{
+  private final SearchService nexusSearchService;
+  private final SearchUtils searchUtils;
+
+  @Inject
+  public ConanHostedSearchFacetImpl(final SearchService nexusSearchService,
+                                    final SearchUtils searchUtils) {
+    this.nexusSearchService = checkNotNull(nexusSearchService);
+    this.searchUtils = checkNotNull(searchUtils);
+  }
+
+  /*
+  Implements Minimum functionality of searching a recipe based on Name, Group
+  and Channel.
+   */
+  @Override
+  public Content searchRecipes(Context context) {
+    Request request = context.getRequest();
+    Parameters paramsObj = request.getParameters();
+    String params = paramsObj.get("q"); // ?q=params..
+
+    // form ConanCoords from the request, since it is the only
+    // requirement to search for recipes.
+    ConanCoords coords = searchUtils.coordsFromParams(params);
+
+    return searchRecipesFromCoords(coords);
+  }
+
+  @Override
+  public Content searchPackages(Context context) {
+    return null;
+  }
+
+  private Content searchRecipesFromCoords(ConanCoords coords) {
+    QueryBuilder query = searchUtils.getQueryBuilder(
+        coords,
+        getRepository().getName());
+
+    // SortBuilder to get recipes in ascending order
+    List<SortBuilder> sortRecipes = new ArrayList<>();
+    sortRecipes.add(SortBuilders.fieldSort("name.raw").order(SortOrder.ASC));
+
+    SearchResponse searchResponse = nexusSearchService.search(query,
+        sortRecipes,
+        0,
+        10);
+
+    JsonArray allRecipes = searchUtils.getRecipesJSON(searchResponse);
+    allRecipes = searchUtils.filterByChannel(allRecipes, coords.getChannel());
+
+    String recipesResult = searchUtils.getRecipesResult(allRecipes);
+
+    return new Content(new StringPayload(recipesResult, ContentTypes.APPLICATION_JSON));
+  }
+}

--- a/src/main/java/org/sonatype/repository/conan/internal/hosted/search/SearchUtils.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/hosted/search/SearchUtils.java
@@ -1,0 +1,183 @@
+package org.sonatype.repository.conan.internal.hosted.search;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.repository.conan.internal.metadata.ConanCoords;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.QueryStringQueryBuilder;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+
+@Named
+@Singleton
+public class SearchUtils
+{
+  /**
+   * Returns a ConanCoords object that represents the recipe info
+   * required for a search.
+   */
+  public ConanCoords coordsFromParams(String paramQ) {
+    String packageName = "*";
+    String version = "*";
+    String group = "*";
+    String channel = "*";
+
+    if(paramQ!=null) {
+      String [] atSeparated = paramQ.split("@");
+
+      if(atSeparated.length==2) {
+        String [] afterAt = atSeparated[1].split("/");
+        if(afterAt.length==2) channel = afterAt[1];
+        if(afterAt.length!=0) group = afterAt[0];
+      }
+
+      String [] beforeAt = atSeparated[0].split("/");
+      if(beforeAt.length==2) version = beforeAt[1];
+      if(beforeAt.length!=0) packageName = beforeAt[0];
+    }
+
+    return new ConanCoords(group, packageName, version, channel, "*");
+  }
+
+  /**
+   * Receives parameters for package path: package/version@user/channel(ConanCoords)
+   * @return QueryBuilder for ElasticSearch based on parameters
+   */
+  QueryBuilder getQueryBuilder(ConanCoords coords, String repoName) {
+    QueryStringQueryBuilder nameQuery = QueryBuilders.queryStringQuery(coords.getProject())
+        .field("name.raw");
+
+    // since semver searches do not work properly with conan search. Do not use this
+    QueryStringQueryBuilder versionQuery = QueryBuilders.queryStringQuery(coords.getVersion())
+        .field("version");
+
+    // for nexus elastic search user is group
+    QueryStringQueryBuilder groupQuery = QueryBuilders.queryStringQuery(coords.getGroup())
+        .field("group.raw");
+
+    QueryStringQueryBuilder repoQuery = QueryBuilders.queryStringQuery(repoName)
+        .field("repository_name");
+
+    QueryBuilder query = QueryBuilders.boolQuery()
+        .must(nameQuery)
+        .must(versionQuery)
+        .must(groupQuery)
+        .must(repoQuery);
+
+    return query;
+  }
+
+  /**
+   * This method receives a SearchResponse, which contains json
+   * of the form:
+   * $$$$$$$$$$$$$$$$$$
+   * {
+   *    ....
+   *    "hits":{
+   *       ....
+   *       "hits":[
+   *          {
+   *             ....
+   *             "_source":{
+   *                "isPrerelease":false,
+   *                "assets":[
+   *                   {
+   *                      "content_type":"application/gzip",
+   *                      "name":"/v1/conans/conan/zlib/1.2.11/stable/conan_export.tgz",
+   *                      .....
+   *                   },
+   *                  .......
+   * 				]
+   *          },
+   *          {
+   *             ....
+   *          }
+   * ...
+   * $$$$$$$$$$$$$
+   * So we have a "hits" object that contains a hits array. This hits array groups recipes and
+   * gives info about the content of everything inside the recipe. So what we basically do
+   * is that extract the first content of a 'hit' (from "assets" object)
+   * and then get the "name" attribute.
+   * Then this name 'attribute' is used to generate the recipe string.
+   *
+   * @param searchResponse The complete json result of search to ElasticSearch
+   * @return A json(String) of all the recipe info that conan client can recognize
+   * Conan wants recipe info in form: {results: ["recipe1", "recipe2"....]}
+   */
+  public JsonArray  getRecipesJSON(SearchResponse searchResponse) {
+    // TODO Get only the recipe name from Elastic Search, not the whole directory listing
+
+    JsonArray allHits = this.getAllHits(searchResponse);
+    JsonArray results = new JsonArray();
+
+    // now using the name attribute of the first member from
+    // "assets" attribute and get the recipe info
+    String recipe;
+    for (JsonElement elem : allHits) {
+      JsonElement temp = elem.getAsJsonObject()
+          .getAsJsonObject("_source")
+          .getAsJsonArray("assets")
+          .get(0)
+          .getAsJsonObject()
+          .get("name");
+
+      recipe = this.nexusAssetToRecipe(temp.toString());
+      results.add(new JsonPrimitive(recipe));
+    }
+
+    return results;
+  }
+
+  public JsonArray filterByChannel(JsonArray arr, String channelStr) {
+    JsonArray filtered = new JsonArray();
+    String recipe;
+    int channelPos;
+    for(JsonElement elem : arr) {
+      recipe = elem.getAsString();
+      channelPos = recipe.lastIndexOf('/') + 1;
+
+      if(recipe.substring(channelPos).equals(channelStr) || channelStr=="*")
+        filtered.add(elem);
+    }
+    return filtered;
+  }
+
+  public String getRecipesResult(JsonArray arr) {
+    JsonObject finalResult = new JsonObject();
+    finalResult.add("results", arr);
+    return finalResult.toString();
+  }
+
+  private JsonArray getAllHits(SearchResponse searchResponse) {
+    JsonObject responseJson;
+    responseJson = new JsonParser().parse(searchResponse.toString()).getAsJsonObject();
+    responseJson = responseJson.getAsJsonObject("hits"); // first hits object
+
+    // hits array containing all the recipes and their contents
+    return responseJson.getAsJsonArray("hits");
+  }
+
+  /**
+   * Converts an asset name obtained by querying to elastic search to
+   * conan equivalent recipe name:
+   *
+   * @param assetName String like - "/v1/conans/conan/zlib/1.2.11/stable/conan_export.tgz"
+   *
+   * @return recipe name from assetName: zlib/1.2.11@conan/stable
+   * */
+  public String nexusAssetToRecipe(String assetName) {
+    String [] symbols = assetName.split("/");
+    return symbols[4] + "/" +
+        symbols[5] + "@" +
+        symbols[3] + '/' +
+        symbols[6];
+  }
+}


### PR DESCRIPTION
## Make version ranges for dependencies work in _requires_ section of conanfile
Loosely related to issue #13 

### The Problem:
Dependencies for a project can be specified in a conanfile as:
```
[requires]
Poco/1.7.9@pocoproject/stable
Hello/[>2.0.0, loose=False, include_prerelease=True]@demo/testing

[generators]
cmake
```
Let us suppose that we have following packages for Hello in our online repo:
```
Hello/3.0.0@demo/stable
Hello/3.1.1-pre.1@demo/testing        
Hello/3.1.1-pre.10@demo/testing 
Hello/3.1.1-pre.2@demo/testing  
Hello/3.1.1-pre.3@demo/testing 
```

For the first Poco recipe, conan is able to fetch the files properly. For the second, however, conan fails; when based on the requirements, it should fetch the pre.3 recipe. 
The problem is that, when we specify a full recipe name, then conan-front end directly asks for download_urls for the recipies, which is implemented by the nexus-conan plugin. 
But, in case of version ranges, first conan sends search request similar to:
```
conan search "Hello/*@demo/testing" -r the-repo-server
```
Here, it tries to get all the versions of a repository that matches with group and channel as well. But the search endpoints are not implemented. 
With this patch conan-plugin is able to understand language in the form above. 

### Some Limitations with the patch
The aim of this patch is to make recipe based search work. But, the intended behaviour of the patch works without version based search. For a given recipe query like: **Poco/[>3.0.0 <6.0.0]@abc/xyz**,  we extract the version part and use the SearchService provided by nexus sources to query with those versions. But, the use case that I found with the nexus SearchService is not reliable to work with these semver type versioning. Further, there is another side to the search: whole package info. For eg, when we specify full recipe name: Poco/1.7.9@pocoproject/stable on a search request, the server sends info for all the existing package variants. But, this part is not implemented here.

### Stack used for development
1. Nexus 3.16.0-01
2. Conan 1.12.0, (Conan 1.11.0)
3. Nexus-Repository-Conan

##### Stack installation:
1. Nexus 3.16.0-01: Binaries were downloaded from https://www.sonatype.com/nexus-repository-oss. Then it can be run by: ``` ./bin/nexus run ```
2. Conan front end was installed using: ```pip3 install conan==1.12```
3. Sources for Nexus-Repository-Conan were downloaded from:  https://github.com/sonatype-nexus-community/nexus-repository-conan. Then, the plugin was attached to the nexus using the instructions in the **(most) Permanent Install** section of the README file. Extract:

++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
### (most) Permanent Install

If you are trying to use the Conan plugin permanently, it likely makes more sense to do the following:

* Copy the bundle into `<nexus_dir>/system/org/sonatype/nexus/plugins/nexus-repository-conan/0.0.6/nexus-repository-conan-0.0.6.jar`
* If you are using OSS edition, make these mods in: `<nexus_dir>/system/com/sonatype/nexus/assemblies/nexus-oss-feature/3.x.y/nexus-oss-feature-3.x.y-features.xml`
* If you are using PRO edition, make these mods in: `<nexus_dir>/system/com/sonatype/nexus/assemblies/nexus-pro-feature/3.x.y/nexus-pro-feature-3.x.y-features.xml`
   ```
         <feature version="3.x.y.xy" prerequisite="false" dependency="false">nexus-repository-rubygems</feature>
         <feature version="0.0.6" prerequisite="false" dependency="false">nexus-repository-conan</feature>
         <feature version="3.x.y.xy" prerequisite="false" dependency="false">nexus-repository-yum</feature>
     </features>
   ```
   And
   ```
       <feature name="nexus-repository-conan" description="org.sonatype.nexus.plugins:nexus-repository-conan" version="0.0.6">
        <details>org.sonatype.nexus.plugins:nexus-repository-conan</details>
        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-conan/0.0.6</bundle>
       </feature>
    </features>
   ```
This will cause the plugin to be loaded and started with each startup of Nexus Repository.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

##### Known Issues with other versions:
When other requirements are kept the same, and if Conan **1.15** is used then it will not send request to the server properly. And the packages will not be fetched.

### The incomplete Conan Plugin
From above, we now know that recipe based search funtionality needs to be implemented in the nexus-conan-plugin. The steps that follow briefly summarize the findings and steps that were taken to fullfill the requirements. 


### Developmemt process
The following was done to trace the calls made to the nexus server by conan client:
```
export CONAN_TRACE_FILE=/tmp/home/conan-trace.log
```
In this file, we can view the rest queries made to the corresponding server and realize the api endpoints that need to be added.

### Setting up API endpoints
API endpoints for search are added. The conan client can perform search in basically three ways:
1. Empty search - when nothing is specified in the search:
```
conan search -r conan-center
```
Then the following request will be made:
```
https://conan.bintray.com/v1/conans/search
```

2. Specifying some keywords: Requests for incomplete recipe names such as:
```
conan search Poco -r conan-center
conan search Poco/1.7.8p3@* -r conan-center
```
will have their requests as:
```
https://conan.bintray.com/v1/conans/search?=
```

3. When specifying full package reference:
```
conan search Poco/1.7.8p3@pocoproject/stable -r conan-center 
```
will have:
```
https://conan.bintray.com/v1/conans/Poco/1.7.8p3/pocoproject/stable/search?
```

Based on these api requests, HostedHandlers and ConanHostedRecipe were modified. To work on these request a new package was created: org.sonatype.repository.conan.internal.hosted.search;

This patch has minimal recipe based search functionality with limitations for searching by version ranges.

### Extracting recipes from conan front end query

After creating handlers and routes (HostedHandlers and ConanHostedRecipe), the main task of generating the search result was done in **search/ConanHostedSearchImpl** file.

Since nexus uses elastic search to query and store data (maybe...), a query has to be formed based on the request from the conan client. 

Elastic search public interface is used to query for search result. The problem here as of now is that when searching for a package, elastic search returns the names of all the files contained in the package as well. This is not the behaviour we want while searching for recipes. Until an alternative is found, the followng works as well. The response from elastic search is something like:
```
{  
   "took":66,
   "timed_out":false,
   "_shards":{  
      "total":6,
      "successful":6,
      "failed":0
   },
   "hits":{  
      "total":2,
      "max_score":1.8728045,
      "hits":[
        {
            "_index":"a3c2cfd22bbb7e92dc12671c05dc5298cc29a1c6",
            "_type":"component",
            "_id":"36e3dec8de528c9b812ce6e257caaf97",
            "_score":1.8728045,
            "_source":{
                "isPrerelease":false,
                "assets":[
                    {
                    "content_type":"application/gzip",
                    "name":"/v1/conans/conan/zlib/1.2.11/stable/conan_export.tgz",
                    "attributes":{
                        .....
                        ...
                    },
                    "id":"4b378653591c6722b70e482861f32f9a"
                    },
                    ....
                    ....
                    {
                    "content_type":"text/plain",
                    "name":"/v1/conans/conan/zlib/1.2.11/stable/packages/51b39bbf59d48fe09b7ac83ddab65ed9b30af19c/download_urls",
                    "attributes":{
                        ....
                        ....
                    },
                    "id":"4b378653591c6722a9feb24a294c454a"
                    }
                ],
                "format":"conan",
                "name":"zlib",
                "attributes":{

                },
                ....
                .....
            }
        },
        {
            "_index":"a3c2cfd22bbb7e92dc12671c05dc5298cc29a1c6",
            "_type":"component",
            "_id":"36e3dec8de528c9b343d5b0c2316afa8",
            "_score":1.8728045,
            "_source":{
                "isPrerelease":false,
                "assets":[
                    {
                    "content_type":"application/gzip",
                    "name":"/v1/conans/conan/zlib/1.2.8/stable/conan_export.tgz",
                    "attributes":{
                        ...
                        ....
                    },
                    "id":"4b378653591c672242027086aea13c24"
                    },
                    ......
                    ......
                    {
                    "content_type":"text/plain",
                    "name":"/v1/conans/conan/zlib/1.2.8/stable/download_urls",
                    "attributes":{
                        ....
                        ....
                    },
                    "id":"4b378653591c672280e5798dfcd65ebb"
                    }
                ],
                "format":"conan",
                "name":"zlib",
                "attributes":{

                },
                ......
                ......
            }
        }
     ]
     ...
```
What we are interested is the second 'hits', which is the array of all the responses. Each object of the second 'hits' contains info about the individual recipes. 
So for this data set, we perfom the following:
1. Extract the first "hits" object. 
2. Then get the "hits" array. 
3. Traverse each object
4. Extract the first element from the asset. We do this because the 'name' attribute of the asset gives the absolute path of the recipe. And we use this string to form the recipe strings. 
5. Check if the element matches the search query.

The server to which the recipe search request is made should return the json in the following form:
```
{"results":[
    "zlib/1.2.11@conan/stable",
    "zlib/1.2.8@conan/stable",
    "zlib/1.2.9@conan/stable"
]}
```
If there are no results, the results array will simple be empty.