### PR TITLE
use .kar bundle as default install method in docker and docs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,13 @@ ARG NEXUS_BUILD=01
 
 COPY . /nexus-repository-conan/
 RUN cd /nexus-repository-conan/; sed -i "s/3.15.1-01/${NEXUS_VERSION}-${NEXUS_BUILD}/g" pom.xml; \
-    mvn clean package;
+    mvn clean package -PbuildKar;
 
 FROM sonatype/nexus3:$NEXUS_VERSION
 ARG NEXUS_VERSION=3.15.1
 ARG NEXUS_BUILD=01
 ARG CONAN_VERSION=0.0.6
-ARG TARGET_DIR=/opt/sonatype/nexus/system/org/sonatype/nexus/plugins/nexus-repository-conan/${CONAN_VERSION}/
+ARG DEPLOY_DIR=/opt/sonatype/nexus/deploy/
 USER root
-RUN mkdir -p ${TARGET_DIR}; \
-    sed -i 's@nexus-repository-maven</feature>@nexus-repository-maven</feature>\n        <feature prerequisite="false" dependency="false" version="0.0.6">nexus-repository-conan</feature>@g' /opt/sonatype/nexus/system/org/sonatype/nexus/assemblies/nexus-core-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-core-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml; \
-    sed -i 's@<feature name="nexus-repository-maven"@<feature name="nexus-repository-conan" description="org.sonatype.nexus.plugins:nexus-repository-conan" version="0.0.6">\n        <details>org.sonatype.nexus.plugins:nexus-repository-conan</details>\n        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-conan/0.0.6</bundle>\n    </feature>\n    <feature name="nexus-repository-maven"@g' /opt/sonatype/nexus/system/org/sonatype/nexus/assemblies/nexus-core-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-core-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml;
-COPY --from=build /nexus-repository-conan/target/nexus-repository-conan-${CONAN_VERSION}.jar ${TARGET_DIR}
+COPY --from=build /nexus-repository-conan/target/nexus-repository-conan-${CONAN_VERSION}-bundle.kar ${DEPLOY_DIR}
 USER nexus

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
    * [Building](#building)
 * [Using Conan with Nexus Repository Manager 3](#using-conan-with-nexus-repository-manager-3)
 * [Installing the plugin](#installing-the-plugin)
-   * [Easiest Install (beta)](#easiest-install-beta)
+   * [Easiest Install](#easiest-install)
    * [Temporary Install](#temporary-install)
    * [(more) Permanent Install](#more-permanent-install)
    * [(most) Permament Install](#most-permanent-install)
@@ -53,7 +53,7 @@ you need to use this plugin with an older version, please use 0.0.1
 
 To build the project and generate the bundle use Maven
 
-    mvn clean install
+    mvn clean package -PbuildKar
 
 If everything checks out, the bundle for Conan should be available in the `target` folder
 
@@ -78,7 +78,7 @@ The application will now be available from your browser at http://localhost:8081
 There are a range of options for installing the Conan plugin. You'll need to build it first, and
 then install the plugin with the options shown below:
 
-### Easiest Install (beta)
+### Easiest Install
 	
 Thanks to some upstream work in Nexus Repository (versions newer than 3.15), it's become a LOT easier to install a plugin. To install the `conan` plugin, follow these steps:
 


### PR DESCRIPTION
.kar bundle is simpler to build and use, so changed default to use that approach.
