### PR TITLE
Fix for 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG NEXUS_VERSION=3.15.1
 
 FROM maven:3-jdk-8-alpine AS build
-ARG NEXUS_VERSION=3.15.1
+ARG NEXUS_VERSION=3.18.1
 ARG NEXUS_BUILD=01
 
 COPY . /nexus-repository-conan/
@@ -9,7 +9,7 @@ RUN cd /nexus-repository-conan/; sed -i "s/3.15.1-01/${NEXUS_VERSION}-${NEXUS_BU
     mvn clean package -PbuildKar;
 
 FROM sonatype/nexus3:$NEXUS_VERSION
-ARG NEXUS_VERSION=3.15.1
+ARG NEXUS_VERSION=3.18.1
 ARG NEXUS_BUILD=01
 ARG CONAN_VERSION=0.0.6
 ARG DEPLOY_DIR=/opt/sonatype/nexus/deploy/

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.15.0-01</version>
+    <version>3.18.1-01</version>
   </parent>
   <groupId>org.sonatype.repository</groupId>
   <artifactId>nexus-repository-conan</artifactId>

--- a/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
@@ -30,7 +30,7 @@ public class ConanBrowseNodeGenerator
 
   @Override
   public List<BrowsePaths> computeComponentPaths(final Asset asset, final Component component) {
-    return BrowsePaths.fromPaths(computeComponentPath(asset, component), false);
+    return BrowsePaths.fromPaths(createComponentPathList(asset, component), false);
   }
 
   @Override
@@ -38,13 +38,13 @@ public class ConanBrowseNodeGenerator
     checkNotNull(asset);
 
     if(component != null) {
-      return BrowsePaths.fromPaths(computeAssetPath(asset, component), false);
+      return BrowsePaths.fromPaths(createAssetPathList(asset, component), false);
     } else {
       return super.computeAssetPaths(asset, component);
     }
   }
 
-  private List<String> computeComponentPath(final Asset asset, final Component component) {
+  private List<String> createComponentPathList(final Asset asset, final Component component) {
     List<String> componentList = new ArrayList<>();
     componentList.add(component.group());
     componentList.add(component.name());
@@ -60,8 +60,8 @@ public class ConanBrowseNodeGenerator
     return ImmutableList.of(split[split.length-2], split[split.length-1]);
   }
 
-  private List<String> computeAssetPath(final Asset asset, final Component component) {
-    List<String> strings = computeComponentPath(asset, component);
+  private List<String> createAssetPathList(final Asset asset, final Component component) {
+    List<String> strings = createComponentPathList(asset, component);
     strings.addAll(assetSegment(asset.name()));
     return strings;
   }

--- a/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
@@ -54,7 +54,12 @@ public class ConanBrowseNodeGenerator
     List<String> path = createComponentPathList(asset, component);
 
     String[] assetSegments = asset.name().split("/");
-    if(asset.name().contains("packages")) {
+
+    if(assetSegments.length < 2) {
+      return path;
+    }
+
+    if(asset.name().contains("packages") && assetSegments.length >= 4) {
       path.add(assetSegments[assetSegments.length-4]);
     }
 

--- a/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
@@ -61,15 +61,9 @@ public class ConanBrowseNodeGenerator
   }
 
   private List<String> computeAssetPath(final Asset asset, final Component component) {
-    checkNotNull(asset);
-
-    if(component != null) {
-      List<String> strings = computeComponentPath(asset, component);
-      strings.addAll(assetSegment(asset.name()));
-      return strings;
-    } else {
-      return super.computeAssetPath(asset, component);
-    }
+    List<String> strings = computeComponentPath(asset, component);
+    strings.addAll(assetSegment(asset.name()));
+    return strings;
   }
 
 }

--- a/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.sonatype.nexus.repository.browse.BrowsePaths;
 import org.sonatype.nexus.repository.browse.ComponentPathBrowseNodeGenerator;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
@@ -25,6 +26,22 @@ public class ConanBrowseNodeGenerator
 {
   public ConanBrowseNodeGenerator() {
     super();
+  }
+
+  @Override
+  public List<BrowsePaths> computeComponentPaths(final Asset asset, final Component component) {
+    return BrowsePaths.fromPaths(computeComponentPath(asset, component), false);
+  }
+
+  @Override
+  public List<BrowsePaths> computeAssetPaths(final Asset asset, final Component component) {
+    checkNotNull(asset);
+
+    if(component != null) {
+      return BrowsePaths.fromPaths(computeAssetPath(asset, component), false);
+    } else {
+      return super.computeAssetPaths(asset, component);
+    }
   }
 
   private List<String> computeComponentPath(final Asset asset, final Component component) {

--- a/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
@@ -27,8 +27,7 @@ public class ConanBrowseNodeGenerator
     super();
   }
 
-  @Override
-  public List<String> computeComponentPath(final Asset asset, final Component component) {
+  private List<String> computeComponentPath(final Asset asset, final Component component) {
     List<String> componentList = new ArrayList<>();
     componentList.add(component.group());
     componentList.add(component.name());
@@ -36,7 +35,7 @@ public class ConanBrowseNodeGenerator
     return componentList;
   }
 
-  public List<String> assetSegment(final String path) {
+  private List<String> assetSegment(final String path) {
     String[] split = path.split("/");
     if(path.contains("packages")) {
       return ImmutableList.of(split[split.length-4], split[split.length-2], split[split.length-1]);
@@ -44,8 +43,7 @@ public class ConanBrowseNodeGenerator
     return ImmutableList.of(split[split.length-2], split[split.length-1]);
   }
 
-  @Override
-  public List<String> computeAssetPath(final Asset asset, final Component component) {
+  private List<String> computeAssetPath(final Asset asset, final Component component) {
     checkNotNull(asset);
 
     if(component != null) {

--- a/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
@@ -12,8 +12,6 @@ import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.repository.conan.internal.ConanFormat;
 
-import com.google.common.collect.ImmutableList;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -52,17 +50,17 @@ public class ConanBrowseNodeGenerator
     return path;
   }
 
-  private List<String> assetSegment(final String path) {
-    String[] split = path.split("/");
-    if(path.contains("packages")) {
-      return ImmutableList.of(split[split.length-4], split[split.length-2], split[split.length-1]);
-    }
-    return ImmutableList.of(split[split.length-2], split[split.length-1]);
-  }
-
   private List<String> createAssetPathList(final Asset asset, final Component component) {
     List<String> path = createComponentPathList(asset, component);
-    path.addAll(assetSegment(asset.name()));
+
+    String[] assetSegments = asset.name().split("/");
+    if(asset.name().contains("packages")) {
+      path.add(assetSegments[assetSegments.length-4]);
+    }
+
+    path.add(assetSegments[assetSegments.length-2]);
+    path.add(assetSegments[assetSegments.length-1]);
+
     return path;
   }
 

--- a/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
+++ b/src/main/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGenerator.java
@@ -45,11 +45,11 @@ public class ConanBrowseNodeGenerator
   }
 
   private List<String> createComponentPathList(final Asset asset, final Component component) {
-    List<String> componentList = new ArrayList<>();
-    componentList.add(component.group());
-    componentList.add(component.name());
-    componentList.add(component.version());
-    return componentList;
+    List<String> path = new ArrayList<>();
+    path.add(component.group());
+    path.add(component.name());
+    path.add(component.version());
+    return path;
   }
 
   private List<String> assetSegment(final String path) {
@@ -61,9 +61,9 @@ public class ConanBrowseNodeGenerator
   }
 
   private List<String> createAssetPathList(final Asset asset, final Component component) {
-    List<String> strings = createComponentPathList(asset, component);
-    strings.addAll(assetSegment(asset.name()));
-    return strings;
+    List<String> path = createComponentPathList(asset, component);
+    path.addAll(assetSegment(asset.name()));
+    return path;
   }
 
 }

--- a/src/test/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGeneratorTest.java
+++ b/src/test/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGeneratorTest.java
@@ -11,7 +11,7 @@ import org.sonatype.nexus.repository.storage.DefaultComponent;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -36,9 +36,9 @@ public class ConanBrowseNodeGeneratorTest
     Asset asset = createAsset(
         "v1/conans/jsonformoderncpp/2.1.1/vthiery/stable/packages/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/download_urls");
 
-    List<String> assetPath = underTest.computeAssetPath(asset, component);
+    List<BrowsePaths> assetPath = underTest.computeAssetPaths(asset, component);
 
-    assertThat(assetPath, contains("vthiery", "jsonformoderncpp", "2.1.1", "stable", "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9", "download_urls"));
+    assertPaths(assetPath, asList("vthiery", "jsonformoderncpp", "2.1.1", "stable", "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9", "download_urls"));
   }
 
 
@@ -47,9 +47,9 @@ public class ConanBrowseNodeGeneratorTest
     Asset asset = createAsset(
         "/v1/conans/jsonformoderncpp/2.1.1/vthiery/stable/download_urls");
 
-    List<String> assetPath = underTest.computeAssetPath(asset, component);
+    List<BrowsePaths> assetPath = underTest.computeAssetPaths(asset, component);
 
-    assertThat(assetPath, contains("vthiery", "jsonformoderncpp", "2.1.1", "stable", "download_urls"));
+    assertPaths(assetPath, asList("vthiery", "jsonformoderncpp", "2.1.1", "stable", "download_urls"));
   }
 
   private void assertPaths(List<BrowsePaths> paths, List<String> expectedPaths) {

--- a/src/test/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGeneratorTest.java
+++ b/src/test/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGeneratorTest.java
@@ -53,7 +53,6 @@ public class ConanBrowseNodeGeneratorTest
   }
 
   private void assertPaths(List<BrowsePaths> paths, List<String> expectedPaths) {
-    assertThat(expectedPaths.size(), is(expectedPaths.size()));
     assertThat(paths.size(), is(expectedPaths.size()));
 
     String requestPath = "";

--- a/src/test/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGeneratorTest.java
+++ b/src/test/java/org/sonatype/repository/conan/internal/ui/ConanBrowseNodeGeneratorTest.java
@@ -3,6 +3,7 @@ package org.sonatype.repository.conan.internal.ui;
 import java.util.List;
 
 import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.repository.browse.BrowsePaths;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.DefaultComponent;
@@ -11,7 +12,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -48,6 +50,22 @@ public class ConanBrowseNodeGeneratorTest
     List<String> assetPath = underTest.computeAssetPath(asset, component);
 
     assertThat(assetPath, contains("vthiery", "jsonformoderncpp", "2.1.1", "stable", "download_urls"));
+  }
+
+  private void assertPaths(List<BrowsePaths> paths, List<String> expectedPaths) {
+    assertThat(expectedPaths.size(), is(expectedPaths.size()));
+    assertThat(paths.size(), is(expectedPaths.size()));
+
+    String requestPath = "";
+
+    for (int i = 0 ; i < expectedPaths.size() ; i++) {
+      requestPath += expectedPaths.get(i);
+      if (i < expectedPaths.size() - 1) {
+        requestPath += "/";
+      }
+      assertThat(paths.get(i).getBrowsePath(), is(expectedPaths.get(i)));
+      assertThat(paths.get(i).getRequestPath(), is(requestPath));
+    }
   }
 
   private Asset createAsset(String assetName) {


### PR DESCRIPTION
Updated Conan plugin to compile against Nexus v3.18

This pull request makes the following changes:
* Change compute*Path returning List<String> to compute*Paths returning List<BrowsePaths>
* A bit of clean up of variables and helper functions, brought on by the change above
* Updated POM and Dockerfile to compile against Nexus v3.18.1

It relates to the following issue:
* Fixes #66 
