### PR TITLE
Correcting version propagation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
-ARG NEXUS_VERSION=3.15.1
+ARG NEXUS_VERSION=3.18.1
+ARG NEXUS_BUILD=01
 
 FROM maven:3-jdk-8-alpine AS build
-ARG NEXUS_VERSION=3.18.1
-ARG NEXUS_BUILD=01
-
 COPY . /nexus-repository-conan/
-RUN cd /nexus-repository-conan/; sed -i "s/3.15.1-01/${NEXUS_VERSION}-${NEXUS_BUILD}/g" pom.xml; \
-    mvn clean package -PbuildKar;
+RUN cd /nexus-repository-conan/; mvn clean package -PbuildKar;
 
 FROM sonatype/nexus3:$NEXUS_VERSION
-ARG NEXUS_VERSION=3.18.1
-ARG NEXUS_BUILD=01
 ARG CONAN_VERSION=0.0.6
 ARG DEPLOY_DIR=/opt/sonatype/nexus/deploy/
 USER root


### PR DESCRIPTION
Previously, `ARG` scoping produced conflicting version of `.kar` and base nexus image.

This pull request makes the following changes:
* Limiting the number of nexus versions ARGs to just one