### PR TITLE
NEXUS-21938 disabled Conan plugin in HA-Cluster env

### DIFF
--- a/nexus-repository-conan/src/main/java/org/sonatype/repository/conan/internal/proxy/v1/ConanProxyRecipe.groovy
+++ b/nexus-repository-conan/src/main/java/org/sonatype/repository/conan/internal/proxy/v1/ConanProxyRecipe.groovy
@@ -62,8 +62,8 @@ class ConanProxyRecipe
 
   @Inject
   ConanProxyRecipe(@Named(ProxyType.NAME) final Type type,
-                             @Named(ConanFormat.NAME) final Format format,
-                             final ConanProxyApiV1 conanApiV1) {
+                   @Named(ConanFormat.NAME) final Format format,
+                   final ConanProxyApiV1 conanApiV1) {
     super(type, format)
     this.conanApiV1 = conanApiV1
   }

--- a/nexus-repository-conan/src/main/java/org/sonatype/repository/conan/internal/proxy/v1/ConanProxyRecipe.groovy
+++ b/nexus-repository-conan/src/main/java/org/sonatype/repository/conan/internal/proxy/v1/ConanProxyRecipe.groovy
@@ -23,6 +23,8 @@ import org.sonatype.nexus.repository.Type
 import org.sonatype.nexus.repository.proxy.ProxyHandler
 import org.sonatype.nexus.repository.types.ProxyType
 import org.sonatype.nexus.repository.view.ConfigurableViewFacet
+import org.sonatype.nexus.repository.view.handlers.FormatHighAvailabilitySupportHandler
+import org.sonatype.nexus.repository.view.handlers.HighAvailabilitySupportChecker
 import org.sonatype.nexus.repository.view.Route
 import org.sonatype.nexus.repository.view.Router
 import org.sonatype.nexus.repository.view.ViewFacet
@@ -48,16 +50,27 @@ class ConanProxyRecipe
   Provider<ConanProxyFacet> proxyFacet
 
   @Inject
+  HighAvailabilitySupportChecker highAvailabilitySupportChecker
+
+  @Inject
   ProxyHandler proxyHandler
+
+  @Inject
+  FormatHighAvailabilitySupportHandler highAvailabilitySupportHandler
 
   private ConanProxyApiV1 conanApiV1
 
   @Inject
-  protected ConanProxyRecipe(@Named(ProxyType.NAME) final Type type,
+  ConanProxyRecipe(@Named(ProxyType.NAME) final Type type,
                              @Named(ConanFormat.NAME) final Format format,
                              final ConanProxyApiV1 conanApiV1) {
     super(type, format)
     this.conanApiV1 = conanApiV1
+  }
+
+  @Override
+  boolean isFeatureEnabled() {
+    return highAvailabilitySupportChecker.isSupported(getFormat().getValue())
   }
 
   @Override
@@ -81,6 +94,7 @@ class ConanProxyRecipe
 
     builder.route(new Route.Builder()
         .matcher(BrowseUnsupportedHandler.MATCHER)
+        .handler(highAvailabilitySupportHandler)
         .handler(browseUnsupportedHandler)
         .create())
 

--- a/nexus-repository-conan/src/test/java/org/sonatype/repository/conan/internal/proxy/matcher/ConanProxyRecipeTest.java
+++ b/nexus-repository-conan/src/test/java/org/sonatype/repository/conan/internal/proxy/matcher/ConanProxyRecipeTest.java
@@ -1,0 +1,58 @@
+package org.sonatype.repository.conan.internal.proxy.matcher;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.repository.types.ProxyType;
+import org.sonatype.nexus.repository.view.handlers.HighAvailabilitySupportChecker;
+import org.sonatype.repository.conan.internal.ConanFormat;
+import org.sonatype.repository.conan.internal.proxy.v1.ConanProxyApiV1;
+import org.sonatype.repository.conan.internal.proxy.v1.ConanProxyRecipe;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ConanProxyRecipeTest
+    extends TestSupport
+{
+  private static final String CONAN_FORMAT = "conan";
+
+
+  @Mock
+  private ConanFormat conanFormat;
+
+  @Mock
+  private HighAvailabilitySupportChecker highAvailabilitySupportChecker;
+
+  @Mock
+  private ConanProxyApiV1 conanApiV1;
+
+
+  private ConanProxyRecipe conanProxyRecipe;
+
+  @Before
+  public void setUp() {
+    when(conanFormat.getValue()).thenReturn(CONAN_FORMAT);
+    conanProxyRecipe = new ConanProxyRecipe(new ProxyType(), conanFormat, conanApiV1);
+    conanProxyRecipe.setHighAvailabilitySupportChecker(highAvailabilitySupportChecker);
+  }
+
+  @Test
+  public void haEnabledProxyRepository() {
+    when(highAvailabilitySupportChecker.isSupported(CONAN_FORMAT)).thenReturn(true);
+    assertThat(conanProxyRecipe.isFeatureEnabled(), is(equalTo(true)));
+    verify(highAvailabilitySupportChecker).isSupported(CONAN_FORMAT);
+  }
+
+  @Test
+  public void haDisabledProxyRepository() {
+    when(highAvailabilitySupportChecker.isSupported(CONAN_FORMAT)).thenReturn(false);
+    assertThat(conanProxyRecipe.isFeatureEnabled(), is(equalTo(false)));
+    verify(highAvailabilitySupportChecker).isSupported(CONAN_FORMAT);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.19.0-01</nxrm-version>
+    <nxrm-version>3.21.0-SNAPSHOT</nxrm-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
The Conan plugin will not been verified in a HA-Cluster environment, either by manual tests or automatic tests. Disabling the Conan plugin when HA-Cluster is enabled.