### PR TITLE
NEXUS-21938 disabled Conan plugin in HA-Cluster env

### DIFF
--- a/nexus-repository-conan/src/main/java/org/sonatype/repository/conan/internal/common/v1/ConanControllerV1.java
+++ b/nexus-repository-conan/src/main/java/org/sonatype/repository/conan/internal/common/v1/ConanControllerV1.java
@@ -29,6 +29,7 @@ import org.sonatype.nexus.repository.view.Router;
 import org.sonatype.nexus.repository.view.handlers.ConditionalRequestHandler;
 import org.sonatype.nexus.repository.view.handlers.ContentHeadersHandler;
 import org.sonatype.nexus.repository.view.handlers.ExceptionHandler;
+import org.sonatype.nexus.repository.view.handlers.FormatHighAvailabilitySupportHandler;
 import org.sonatype.nexus.repository.view.handlers.HandlerContributor;
 import org.sonatype.nexus.repository.view.handlers.TimingHandler;
 import org.sonatype.repository.conan.internal.AssetKind;
@@ -63,6 +64,9 @@ public class ConanControllerV1
   protected ConditionalRequestHandler conditionalRequestHandler;
 
   @Inject
+  FormatHighAvailabilitySupportHandler highAvailabilitySupportHandler;
+
+  @Inject
   protected PartialFetchHandler partialFetchHandler;
 
   @Inject
@@ -92,6 +96,7 @@ public class ConanControllerV1
         .handler(timingHandler)
         .handler(assetKindHandler(assetKind))
         .handler(securityHandler)
+        .handler(highAvailabilitySupportHandler)
         .handler(exceptionHandler)
         .handler(handlerContributor)
         .handler(conditionalRequestHandler)

--- a/nexus-repository-conan/src/main/java/org/sonatype/repository/conan/internal/proxy/v1/ConanProxyRecipe.groovy
+++ b/nexus-repository-conan/src/main/java/org/sonatype/repository/conan/internal/proxy/v1/ConanProxyRecipe.groovy
@@ -23,12 +23,11 @@ import org.sonatype.nexus.repository.Type
 import org.sonatype.nexus.repository.proxy.ProxyHandler
 import org.sonatype.nexus.repository.types.ProxyType
 import org.sonatype.nexus.repository.view.ConfigurableViewFacet
-import org.sonatype.nexus.repository.view.handlers.FormatHighAvailabilitySupportHandler
-import org.sonatype.nexus.repository.view.handlers.HighAvailabilitySupportChecker
 import org.sonatype.nexus.repository.view.Route
 import org.sonatype.nexus.repository.view.Router
 import org.sonatype.nexus.repository.view.ViewFacet
 import org.sonatype.nexus.repository.view.handlers.BrowseUnsupportedHandler
+import org.sonatype.nexus.repository.view.handlers.HighAvailabilitySupportChecker
 import org.sonatype.repository.conan.internal.ConanFormat
 import org.sonatype.repository.conan.internal.ConanRecipeSupport
 
@@ -54,9 +53,6 @@ class ConanProxyRecipe
 
   @Inject
   ProxyHandler proxyHandler
-
-  @Inject
-  FormatHighAvailabilitySupportHandler highAvailabilitySupportHandler
 
   private ConanProxyApiV1 conanApiV1
 
@@ -94,7 +90,6 @@ class ConanProxyRecipe
 
     builder.route(new Route.Builder()
         .matcher(BrowseUnsupportedHandler.MATCHER)
-        .handler(highAvailabilitySupportHandler)
         .handler(browseUnsupportedHandler)
         .create())
 

--- a/nexus-repository-conan/src/main/java/org/sonatype/repository/conan/internal/proxy/v1/ConanProxyRecipe.groovy
+++ b/nexus-repository-conan/src/main/java/org/sonatype/repository/conan/internal/proxy/v1/ConanProxyRecipe.groovy
@@ -23,6 +23,8 @@ import org.sonatype.nexus.repository.Type
 import org.sonatype.nexus.repository.proxy.ProxyHandler
 import org.sonatype.nexus.repository.types.ProxyType
 import org.sonatype.nexus.repository.view.ConfigurableViewFacet
+import org.sonatype.nexus.repository.view.handlers.FormatHighAvailabilitySupportHandler
+import org.sonatype.nexus.repository.view.handlers.HighAvailabilitySupportChecker
 import org.sonatype.nexus.repository.view.Route
 import org.sonatype.nexus.repository.view.Router
 import org.sonatype.nexus.repository.view.ViewFacet
@@ -48,16 +50,27 @@ class ConanProxyRecipe
   Provider<ConanProxyFacet> proxyFacet
 
   @Inject
+  HighAvailabilitySupportChecker highAvailabilitySupportChecker
+
+  @Inject
   ProxyHandler proxyHandler
+
+  @Inject
+  FormatHighAvailabilitySupportHandler highAvailabilitySupportHandler
 
   private ConanProxyApiV1 conanApiV1
 
   @Inject
-  protected ConanProxyRecipe(@Named(ProxyType.NAME) final Type type,
-                             @Named(ConanFormat.NAME) final Format format,
-                             final ConanProxyApiV1 conanApiV1) {
+  ConanProxyRecipe(@Named(ProxyType.NAME) final Type type,
+                   @Named(ConanFormat.NAME) final Format format,
+                   final ConanProxyApiV1 conanApiV1) {
     super(type, format)
     this.conanApiV1 = conanApiV1
+  }
+
+  @Override
+  boolean isFeatureEnabled() {
+    return highAvailabilitySupportChecker.isSupported(getFormat().getValue())
   }
 
   @Override
@@ -81,6 +94,7 @@ class ConanProxyRecipe
 
     builder.route(new Route.Builder()
         .matcher(BrowseUnsupportedHandler.MATCHER)
+        .handler(highAvailabilitySupportHandler)
         .handler(browseUnsupportedHandler)
         .create())
 

--- a/nexus-repository-conan/src/test/java/org/sonatype/repository/conan/internal/proxy/matcher/ConanProxyRecipeTest.java
+++ b/nexus-repository-conan/src/test/java/org/sonatype/repository/conan/internal/proxy/matcher/ConanProxyRecipeTest.java
@@ -1,0 +1,58 @@
+package org.sonatype.repository.conan.internal.proxy.matcher;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.repository.types.ProxyType;
+import org.sonatype.nexus.repository.view.handlers.HighAvailabilitySupportChecker;
+import org.sonatype.repository.conan.internal.ConanFormat;
+import org.sonatype.repository.conan.internal.proxy.v1.ConanProxyApiV1;
+import org.sonatype.repository.conan.internal.proxy.v1.ConanProxyRecipe;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ConanProxyRecipeTest
+    extends TestSupport
+{
+  private static final String CONAN_FORMAT = "conan";
+
+
+  @Mock
+  private ConanFormat conanFormat;
+
+  @Mock
+  private HighAvailabilitySupportChecker highAvailabilitySupportChecker;
+
+  @Mock
+  private ConanProxyApiV1 conanApiV1;
+
+
+  private ConanProxyRecipe conanProxyRecipe;
+
+  @Before
+  public void setUp() {
+    when(conanFormat.getValue()).thenReturn(CONAN_FORMAT);
+    conanProxyRecipe = new ConanProxyRecipe(new ProxyType(), conanFormat, conanApiV1);
+    conanProxyRecipe.setHighAvailabilitySupportChecker(highAvailabilitySupportChecker);
+  }
+
+  @Test
+  public void haEnabledProxyRepository() {
+    when(highAvailabilitySupportChecker.isSupported(CONAN_FORMAT)).thenReturn(true);
+    assertThat(conanProxyRecipe.isFeatureEnabled(), is(equalTo(true)));
+    verify(highAvailabilitySupportChecker).isSupported(CONAN_FORMAT);
+  }
+
+  @Test
+  public void haDisabledProxyRepository() {
+    when(highAvailabilitySupportChecker.isSupported(CONAN_FORMAT)).thenReturn(false);
+    assertThat(conanProxyRecipe.isFeatureEnabled(), is(equalTo(false)));
+    verify(highAvailabilitySupportChecker).isSupported(CONAN_FORMAT);
+  }
+}

--- a/nexus-repository-conan/src/test/java/org/sonatype/repository/conan/internal/proxy/matcher/ConanProxyRecipeTest.java
+++ b/nexus-repository-conan/src/test/java/org/sonatype/repository/conan/internal/proxy/matcher/ConanProxyRecipeTest.java
@@ -34,7 +34,6 @@ public class ConanProxyRecipeTest
 {
   private static final String CONAN_FORMAT = "conan";
 
-
   @Mock
   private ConanFormat conanFormat;
 
@@ -43,8 +42,7 @@ public class ConanProxyRecipeTest
 
   @Mock
   private ConanProxyApiV1 conanApiV1;
-
-
+  
   private ConanProxyRecipe conanProxyRecipe;
 
   @Before

--- a/nexus-repository-conan/src/test/java/org/sonatype/repository/conan/internal/proxy/matcher/ConanProxyRecipeTest.java
+++ b/nexus-repository-conan/src/test/java/org/sonatype/repository/conan/internal/proxy/matcher/ConanProxyRecipeTest.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.repository.conan.internal.proxy.matcher;
 
 import org.sonatype.goodies.testsupport.TestSupport;

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.19.0-01</nxrm-version>
+    <nxrm-version>3.21.0-SNAPSHOT</nxrm-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
The Conan plugin will not been verified in a HA-Cluster environment, either by manual tests or automatic tests. We should disable the Conan plugin when HA-Cluster is enabled.