### PR TITLE
simplify Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ workflows:
             - approve-release
           ssh-fingerprints: "f3:87:8d:21:0a:df:1e:59:fc:1e:a6:e3:59:f3:35:0f"
           context: rso-base
+          mvn-release-prepare-command: mvn --batch-mode release:prepare -DscmCommentPrefix="[skip ci] [maven-release-plugin] " -PbuildKar
           filters:
             branches:
               only: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,16 @@
-ARG NEXUS_VERSION=3.15.1
+# declaration of NEXUS_VERSION must appear before first FROM command
+# see: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG NEXUS_VERSION=latest
 
 FROM maven:3-jdk-8-alpine AS build
-ARG NEXUS_VERSION=3.18.1
-ARG NEXUS_BUILD=01
 
 COPY . /nexus-repository-conan/
-RUN cd /nexus-repository-conan/; sed -i "s/3.15.1-01/${NEXUS_VERSION}-${NEXUS_BUILD}/g" pom.xml; \
+RUN cd /nexus-repository-conan/; \
     mvn clean package -PbuildKar;
 
 FROM sonatype/nexus3:$NEXUS_VERSION
-ARG NEXUS_VERSION=3.18.1
-ARG NEXUS_BUILD=01
-ARG CONAN_VERSION=0.0.6
+
 ARG DEPLOY_DIR=/opt/sonatype/nexus/deploy/
 USER root
-COPY --from=build /nexus-repository-conan/target/nexus-repository-conan-${CONAN_VERSION}-bundle.kar ${DEPLOY_DIR}
+COPY --from=build /nexus-repository-conan/nexus-repository-conan/target/nexus-repository-conan-*-bundle.kar ${DEPLOY_DIR}
 USER nexus

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ To build the project and generate the bundle use Maven
 
 If everything checks out, the bundle for Conan should be available in the `target` folder
 
+#### Build with Docker
+
+    docker build -t nexus-repository-conan .
+
+#### Run as a Docker container
+
+    docker run -d -p 8081:8081 --name nexus-repository-conan nexus-repository-conan  
+
+For further information like how to persist volumes check out [the GitHub repo for our official image](https://github.com/sonatype/docker-nexus3).
+
+After allowing some time to spin up, the application will be available from your browser at http://localhost:8081.
+
+To read the generated admin password for your first login to the web UI, you can use the command below against the running docker container:
+
+    docker exec -it nexus-repository-conan cat /nexus-data/admin.password && echo
+
+For simplicity, you should check `Enable anonymous access` in the prompts following your first login.   
+
 ## Using Conan with Nexus Repository Manager 3
 
 [We have detailed instructions on how to get started here!](https://help.sonatype.com/repomanager3/formats/conan-repositories)


### PR DESCRIPTION
Removed high maintenance versioning from Dockerfile

I noticed the Conan format didn't appear in the running NXRM docker instance. I wonder if there is a conflict now that Conan is included in NXRM, and when a SNAPSHOT.kar file exists in the `deploy` folder?