### PR TITLE
Release kar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ workflows:
             - approve-release
           ssh-fingerprints: "f3:87:8d:21:0a:df:1e:59:fc:1e:a6:e3:59:f3:35:0f"
           context: rso-base
+          mvn-release-prepare-command: mvn --batch-mode release:prepare -DscmCommentPrefix="[skip ci] [maven-release-plugin] " -PbuildKar
           filters:
             branches:
               only: master


### PR DESCRIPTION
I think this CI config change will ensure the .kar file is published to Central during the release process. 

It relates to the following issue #s:
* Fixes #106 

Might also be related to potential format version conflict in #110.