### PR TITLE
NEXUS-23973 - Fix authentication in ConanResourceIT

### DIFF
--- a/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/rest/ConanResourceITSupport.java
+++ b/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/rest/ConanResourceITSupport.java
@@ -81,11 +81,9 @@ public class ConanResourceITSupport
     CleanupPolicyAttributes cleanup = new CleanupPolicyAttributes(Collections.emptyList());
     ProxyAttributes proxy = new ProxyAttributes(REMOTE_URL, 1, 2);
     NegativeCacheAttributes negativeCache = new NegativeCacheAttributes(false, 1440);
-    HttpClientConnectionAuthenticationAttributes authentication =
-        new HttpClientConnectionAuthenticationAttributes("username", null, null, null, null);
     HttpClientConnectionAttributes connection =
         new HttpClientConnectionAttributes(1, null, 5, false, false);
-    HttpClientAttributes httpClient = new HttpClientAttributes(false, true, connection, authentication);
+    HttpClientAttributes httpClient = new HttpClientAttributes(false, true, connection, null);
 
     // SET YOUR FORMAT DATA
     return new ConanProxyRepositoryApiRequest(PROXY_NAME, true, storage, cleanup,


### PR DESCRIPTION
ConanResourceIT creates an empty authentication object. This doesn't cause a test failure because saving the authentication info is broken in all REST APIs for the current Nexus Repository Manager release.

The next release of Nexus Repository Manager fixes this bug which will then cause this test to fail. 

This pull request makes the following changes:
* removes creation of empty authentication object
