### PR TITLE
NEXUS-22489 fixed IT updates

### DIFF
--- a/nexus-repository-conan-it/pom.xml
+++ b/nexus-repository-conan-it/pom.xml
@@ -86,6 +86,13 @@
       <version>${nxrm-version}</version>
       <type>zip</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Avoid leaking older r plugins from distro -->
+        <exclusion>
+          <groupId>org.sonatype.nexus.plugins</groupId>
+          <artifactId>nexus-repository-conan</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/nexus-repository-conan-it/pom.xml
+++ b/nexus-repository-conan-it/pom.xml
@@ -87,7 +87,7 @@
       <type>zip</type>
       <scope>test</scope>
       <exclusions>
-        <!-- Avoid leaking older r plugins from distro -->
+        <!-- Avoid leaking older conan plugins from distro -->
         <exclusion>
           <groupId>org.sonatype.nexus.plugins</groupId>
           <artifactId>nexus-repository-conan</artifactId>

--- a/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/ConanITConfig.java
+++ b/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/ConanITConfig.java
@@ -1,0 +1,20 @@
+package org.sonatype.nexus.plugins.conan;
+
+import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
+import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
+
+import org.ops4j.pax.exam.Option;
+
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.sonatype.nexus.pax.exam.NexusPaxExamSupport.nexusFeature;
+
+public class ConanITConfig
+{
+  public static Option[] configureConanBase() {
+    return NexusPaxExamSupport.options(
+        NexusITSupport.configureNexusBase(),
+        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-conan"),
+        systemProperty("nexus-exclude-features").value("nexus-cma-community")
+    );
+  }
+}

--- a/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/ConanITConfig.java
+++ b/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/ConanITConfig.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.plugins.conan;
 
 import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;

--- a/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/internal/CleanupTaskConanProxyIT.java
+++ b/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/internal/CleanupTaskConanProxyIT.java
@@ -21,7 +21,6 @@ import org.sonatype.nexus.common.app.BaseUrlHolder;
 import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.plugins.conan.internal.fixtures.RepositoryRuleConan;
 import org.sonatype.nexus.repository.Repository;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 import org.sonatype.nexus.testsuite.testsupport.cleanup.CleanupITSupport;
 
 import org.junit.After;
@@ -30,6 +29,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
+
+import static org.sonatype.nexus.plugins.conan.ConanITConfig.configureConanBase;
 
 public class CleanupTaskConanProxyIT
     extends CleanupITSupport
@@ -69,10 +70,7 @@ public class CleanupTaskConanProxyIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-conan")
-    );
+    return configureConanBase();
   }
 
   @Before

--- a/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/internal/ConanProxyIT.java
+++ b/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/internal/ConanProxyIT.java
@@ -17,14 +17,12 @@ import java.io.IOException;
 import org.sonatype.goodies.httpfixture.server.fluent.Behaviours;
 import org.sonatype.goodies.httpfixture.server.fluent.Server;
 import org.sonatype.nexus.common.app.BaseUrlHolder;
-import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.http.HttpStatus;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.ComponentMaintenance;
 import org.sonatype.nexus.repository.view.ContentTypes;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 import org.sonatype.repository.conan.internal.ConanFormat;
 
 import com.google.gson.JsonObject;
@@ -41,6 +39,7 @@ import org.ops4j.pax.exam.Option;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.sonatype.nexus.plugins.conan.ConanITConfig.configureConanBase;
 import static org.sonatype.nexus.testsuite.testsupport.FormatClientSupport.status;
 
 public class ConanProxyIT
@@ -130,10 +129,7 @@ public class ConanProxyIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-conan")
-    );
+    return configureConanBase();
   }
 
   @Before

--- a/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/internal/ConanProxySearchIT.java
+++ b/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/internal/ConanProxySearchIT.java
@@ -15,12 +15,10 @@ package org.sonatype.nexus.plugins.conan.internal;
 import org.sonatype.goodies.httpfixture.server.fluent.Behaviours;
 import org.sonatype.goodies.httpfixture.server.fluent.Server;
 import org.sonatype.nexus.common.app.BaseUrlHolder;
-import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.http.HttpStatus;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.view.ContentTypes;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 import org.sonatype.repository.conan.internal.ConanFormat;
 
 import org.apache.http.Header;
@@ -36,6 +34,7 @@ import org.ops4j.pax.exam.Option;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.sonatype.nexus.plugins.conan.ConanITConfig.configureConanBase;
 import static org.sonatype.nexus.testsuite.testsupport.FormatClientSupport.status;
 
 public class ConanProxySearchIT
@@ -82,10 +81,7 @@ public class ConanProxySearchIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-conan")
-    );
+    return configureConanBase();
   }
 
   @Before

--- a/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/rest/ConanResourceIT.java
+++ b/nexus-repository-conan-it/src/test/java/org/sonatype/nexus/plugins/conan/rest/ConanResourceIT.java
@@ -30,16 +30,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.sonatype.nexus.plugins.conan.ConanITConfig.configureConanBase;
 
 public class ConanResourceIT
     extends ConanResourceITSupport
 {
   @Configuration
   public static Option[] configureNexus() {
-    return options(
-        configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-conan")
-    );
+    return configureConanBase();
   }
 
   @Before

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.24.0-01</version>
+    <version>3.25.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>conan-parent</artifactId>
@@ -46,7 +46,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.24.0-01</nxrm-version>
+    <nxrm-version>3.25.0-SNAPSHOT</nxrm-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
ITs now use the actual repository code instead of the version of the plugin from the parent (NXRM)

The issue explains the problem for R format https://issues.sonatype.org/browse/NEXUS-22489